### PR TITLE
2GB filesize limit on 32bit Linux

### DIFF
--- a/Makefile.common
+++ b/Makefile.common
@@ -1,5 +1,5 @@
 #CC=gcc
-CFLAGS =-std=gnu11 -DENABLE_SSL -DENABLE_IPV6 -Wall -Wfatal-errors -Os -fstack-protector -I libircclient-include/
+CFLAGS =-std=gnu11 -D_FILE_OFFSET_BITS=64 -DENABLE_SSL -DENABLE_IPV6 -Wall -Wfatal-errors -Os -fstack-protector -I libircclient-include/
 #CFLAGS += -DHOSTNAME_VALIDATION
 #CFLAGS += -DDEBUG
 LIBS = -lssl -lcrypto -lpthread


### PR DESCRIPTION
Me again. I just ran into this problem, downloads would stop after the 2GB mark was reached. Easy solution (if you compile on 32bit Linux) add:

-D_FILE_OFFSET_BITS=64

to Makefile.common and 2GB problems are solved.
